### PR TITLE
rename nLats and nLons

### DIFF
--- a/src/convert_mpas.F
+++ b/src/convert_mpas.F
@@ -153,7 +153,7 @@ program convert_mpas
         if (nRecordsOut == 0) then
             write(0,*) 'Defining fields in output file'
 
-            ! Define 'lat' and 'lon' fields for target mesh
+            ! Define 'latitude' and 'longitude' fields for target mesh
             stat = remap_get_target_latitudes(remap_info, target_field)
             stat = file_output_register_field(output_handle, target_field)
             stat = free_target_field(target_field)
@@ -190,7 +190,7 @@ program convert_mpas
 
 
         ! 
-        ! Write 'lat' and 'lon' fields for target mesh
+        ! Write 'latitude' and 'longitude' fields for target mesh
         ! 
         if (nRecordsOut == 0) then
             stat = remap_get_target_latitudes(remap_info, target_field)

--- a/src/convert_mpas.F
+++ b/src/convert_mpas.F
@@ -153,7 +153,7 @@ program convert_mpas
         if (nRecordsOut == 0) then
             write(0,*) 'Defining fields in output file'
 
-            ! Define 'latitude' and 'longitude' fields for target mesh
+            ! Define 'lat' and 'lon' fields for target mesh
             stat = remap_get_target_latitudes(remap_info, target_field)
             stat = file_output_register_field(output_handle, target_field)
             stat = free_target_field(target_field)
@@ -186,10 +186,11 @@ program convert_mpas
                 stat = scan_input_free_field(field)
             end do
         end if
+        stat = add_latlon_atts(output_handle)
 
 
         ! 
-        ! Write 'latitude' and 'longitude' fields for target mesh
+        ! Write 'lat' and 'lon' fields for target mesh
         ! 
         if (nRecordsOut == 0) then
             stat = remap_get_target_latitudes(remap_info, target_field)

--- a/src/convert_mpas.F
+++ b/src/convert_mpas.F
@@ -186,7 +186,6 @@ program convert_mpas
                 stat = scan_input_free_field(field)
             end do
         end if
-        stat = add_latlon_atts(output_handle)
 
 
         ! 

--- a/src/convert_mpas.F
+++ b/src/convert_mpas.F
@@ -185,14 +185,10 @@ program convert_mpas
                 end if
                 stat = scan_input_free_field(field)
             end do
-        end if
-        stat = add_latlon_atts(output_handle)
 
-
-        ! 
-        ! Write 'lat' and 'lon' fields for target mesh
-        ! 
-        if (nRecordsOut == 0) then
+            ! 
+            ! Write 'lat' and 'lon' fields for target mesh
+            ! 
             stat = remap_get_target_latitudes(remap_info, target_field)
             stat = file_output_write_field(output_handle, target_field, frame=0)
             stat = free_target_field(target_field)
@@ -200,9 +196,13 @@ program convert_mpas
             stat = remap_get_target_longitudes(remap_info, target_field)
             stat = file_output_write_field(output_handle, target_field, frame=0)
             stat = free_target_field(target_field)
+
+            ! Add units, long_name, standard_name attribute to coordinate variables.
+            stat = add_latlon_atts(output_handle)
+    
         end if
 
-    
+
         !
         ! Loop over all times in the input file
         !

--- a/src/convert_mpas.F
+++ b/src/convert_mpas.F
@@ -162,6 +162,7 @@ program convert_mpas
             stat = file_output_register_field(output_handle, target_field)
             stat = free_target_field(target_field)
 
+
             do while (scan_input_next_field(handle, field) == 0) 
                 if (can_remap_field(field) .and. &
                     should_remap_field(field, include_field_list, exclude_field_list)) then
@@ -185,6 +186,7 @@ program convert_mpas
                 stat = scan_input_free_field(field)
             end do
         end if
+        stat = add_latlon_atts(output_handle)
 
 
         ! 

--- a/src/copy_atts.F
+++ b/src/copy_atts.F
@@ -61,4 +61,27 @@ module copy_atts
 
     end function copy_field_atts
 
+    ! Add attributes to lat or lon field
+    integer function add_latlon_atts(handle) result(stat)
+
+        implicit none
+
+        type (output_handle_type) :: handle
+
+        integer :: varid
+
+        stat = 0
+
+        stat = NF90_INQ_VARID(handle%ncid, 'latitude', varid)
+        stat = NF90_PUT_ATT(handle % ncid, varid, 'units', 'degree_north')
+        stat = NF90_PUT_ATT(handle % ncid, varid, 'long_name', 'latitude')
+        stat = NF90_PUT_ATT(handle % ncid, varid, 'standard_name', 'latitude')
+
+        stat = NF90_INQ_VARID(handle%ncid, 'longitude', varid)
+        stat = NF90_PUT_ATT(handle % ncid, varid, 'units', 'degree_east')
+        stat = NF90_PUT_ATT(handle % ncid, varid, 'long_name', 'longitude')
+        stat = NF90_PUT_ATT(handle % ncid, varid, 'standard_name', 'longitude')
+
+    end function add_latlon_atts
+
 end module copy_atts

--- a/src/copy_atts.F
+++ b/src/copy_atts.F
@@ -61,27 +61,4 @@ module copy_atts
 
     end function copy_field_atts
 
-    ! Add attributes to lat or lon field
-    integer function add_latlon_atts(handle) result(stat)
-
-        implicit none
-
-        type (output_handle_type) :: handle
-
-        integer :: varid
-
-        stat = 0
-
-        stat = NF90_INQ_VARID(handle%ncid, 'latitude', varid)
-        stat = NF90_PUT_ATT(handle % ncid, varid, 'units', 'degree_north')
-        stat = NF90_PUT_ATT(handle % ncid, varid, 'long_name', 'latitude')
-        stat = NF90_PUT_ATT(handle % ncid, varid, 'standard_name', 'latitude')
-
-        stat = NF90_INQ_VARID(handle%ncid, 'longitude', varid)
-        stat = NF90_PUT_ATT(handle % ncid, varid, 'units', 'degree_east')
-        stat = NF90_PUT_ATT(handle % ncid, varid, 'long_name', 'longitude')
-        stat = NF90_PUT_ATT(handle % ncid, varid, 'standard_name', 'longitude')
-
-    end function add_latlon_atts
-
 end module copy_atts

--- a/src/remapper.F
+++ b/src/remapper.F
@@ -334,9 +334,9 @@ module remapper
         end do
 
         dst_field % dimlens(dst_field % ndims-1) = remap_info % dst_mesh % nlon
-        dst_field % dimnames(dst_field % ndims-1) = 'nLons'
+        dst_field % dimnames(dst_field % ndims-1) = 'longitude'
         dst_field % dimlens(dst_field % ndims) = remap_info % dst_mesh % nlat
-        dst_field % dimnames(dst_field % ndims) = 'nLats'
+        dst_field % dimnames(dst_field % ndims) = 'latitude'
 
     end function remap_field_dryrun
 
@@ -400,9 +400,9 @@ module remapper
             dst_field % dimnames(idim) = src_field % dimnames(idim)
         end do
         dst_field % dimlens(dst_field % ndims-1) = remap_info % dst_mesh % nlon
-        dst_field % dimnames(dst_field % ndims-1) = 'nLons'
+        dst_field % dimnames(dst_field % ndims-1) = 'longitude'
         dst_field % dimlens(dst_field % ndims) = remap_info % dst_mesh % nlat
-        dst_field % dimnames(dst_field % ndims) = 'nLats'
+        dst_field % dimnames(dst_field % ndims) = 'latitude'
 
         if (src_field % xtype == FIELD_TYPE_REAL) then
             if (dst_field % ndims == 2) then
@@ -594,7 +594,7 @@ module remapper
         stat = 0
 
 
-        lat_field % name = 'lat'
+        lat_field % name = 'latitude'
         lat_field % xtype = FIELD_TYPE_REAL
         lat_field % ndims = 1
         lat_field % isTimeDependent = .false.
@@ -602,7 +602,7 @@ module remapper
         allocate(lat_field % dimnames(lat_field % ndims))
         allocate(lat_field % dimlens(lat_field % ndims))
 
-        lat_field % dimnames(1) = 'nLats'
+        lat_field % dimnames(1) = 'latitude'
         lat_field % dimlens(1) = remap_info % dst_mesh % nlat
 
         allocate(lat_field % array1r(lat_field % dimlens(1)))
@@ -623,7 +623,7 @@ module remapper
         stat = 0
 
 
-        lon_field % name = 'lon'
+        lon_field % name = 'longitude'
         lon_field % xtype = FIELD_TYPE_REAL
         lon_field % ndims = 1
         lon_field % isTimeDependent = .false.
@@ -631,7 +631,7 @@ module remapper
         allocate(lon_field % dimnames(lon_field % ndims))
         allocate(lon_field % dimlens(lon_field % ndims))
 
-        lon_field % dimnames(1) = 'nLons'
+        lon_field % dimnames(1) = 'longitude'
         lon_field % dimlens(1) = remap_info % dst_mesh % nlon
 
         allocate(lon_field % array1r(lon_field % dimlens(1)))


### PR DESCRIPTION
Changing the dimension and variable names to _longitude_ and _latitude_ complies with CF conventions. This, in combination with _units_ and _long_name_ attributes, allows ncview to automatically overlay continents and state boundaries on all spatial fields.

WARNING : This change breaks downstream programs that expect the old names (_lat_ and _lon_) or old dimension names (_nLats_ and _nLons_).

```
variables:
float latitude(latitude) ;
        latitude:units = "degree_north" ;
        latitude:long_name = "latitude" ;
        latitude:standard_name = "latitude" ;
float longitude(longitude) ;
        longitude:units = "degree_east" ;
        longitude:long_name = "longitude" ;
        longitude:standard_name = "longitude" ;

```
Added "standard_name" attribute per CF convention. 

