### PR TITLE
Fix bugs in the interpolation of edge- and vertex-based fields

### DIFF
--- a/src/remapper.F
+++ b/src/remapper.F
@@ -182,7 +182,7 @@ module remapper
                                              6371229.0)
             end do
             remap_info % vertexWeights(:,ix,iy) = 0.0
-            remap_info % vertexWeights(1:nn,ix,iy) = mpas_wachspress_coordinates(3, vertCoords(:,1:nn), pointInterp)
+            remap_info % vertexWeights(1:nn,ix,iy) = mpas_wachspress_coordinates(nn, vertCoords(:,1:nn), pointInterp)
         end do
         end do
 
@@ -210,7 +210,7 @@ module remapper
                                              6371229.0)
             end do
             remap_info % edgeWeights(:,ix,iy) = 0.0
-            remap_info % edgeWeights(1:nn,ix,iy) = mpas_wachspress_coordinates(3, vertCoords(:,1:nn), pointInterp)
+            remap_info % edgeWeights(1:nn,ix,iy) = mpas_wachspress_coordinates(nn, vertCoords(:,1:nn), pointInterp)
         end do
         end do
 

--- a/src/remapper.F
+++ b/src/remapper.F
@@ -863,9 +863,12 @@ module remapper
         ! output
         real, dimension(nVertices) :: mpas_wachspress_coordinates
 
+        ! parameters
+        integer, parameter :: RHI = selected_real_kind(12)
+
         ! computational intermediates
-        real, dimension(nVertices) :: wach       ! The wachpress area-product
-        real :: wach_total                       ! The wachpress total weight
+        real(kind=RHI), dimension(nVertices) :: wach       ! The wachpress area-product
+        real(kind=RHI) :: wach_total                       ! The wachpress total weight
         integer :: i, j                                       ! Loop indices
         integer :: im1, i0, ip1                               ! im1 = (i-1), i0 = i, ip1 = (i+1)
   
@@ -933,7 +936,7 @@ module remapper
         ! compute lambda
         mpas_wachspress_coordinates= 0.0
         do i = 1, nVertices
-            mpas_wachspress_coordinates(i) = wach(i)/wach_total
+            mpas_wachspress_coordinates(i) = real(wach(i)/wach_total)
         end do
 
     end function mpas_wachspress_coordinates


### PR DESCRIPTION
This merge introduces two fixes to the `remapper` module to properly
interpolate fields defined on edges and vertices. The first fix addresses 
an incorrectly specified number of vertices for the polygons associated
with edges and vertices, while the second fix address numerical issues 
that can occur when the source mesh is coarse.