### PR TITLE
Improve logic for handling input files with no unlimited dimension

### DIFF
--- a/src/scan_input.F
+++ b/src/scan_input.F
@@ -100,10 +100,14 @@ module scan_input
         end if
 
         if (present(nRecords)) then
-            stat = nf90_inquire_dimension(handle % ncid, handle % unlimited_dimid, len=nRecords)
-            if (stat /= NF90_NOERR) then
-                stat = 1
-                return
+            if (handle % unlimited_dimid /= -1) then
+                stat = nf90_inquire_dimension(handle % ncid, handle % unlimited_dimid, len=nRecords)
+                if (stat /= NF90_NOERR) then
+                   stat = 1
+                   return
+                end if
+            else
+                nRecords = 0
             end if
 
             ! In case we have an input file that no time-varying records but


### PR DESCRIPTION
This merge improves the logic for handling input files that have no netCDF
unlimited dimension.

When inquiring about the size of a non-existent unlimited dimension
through the nf90_inquire_dimension routine, some versions of the netCDF
library return a zero length, while others do not. This leads to
failures like the following when trying to convert, e.g., a mesh file:
```
 Remapping MPAS fields from file 'grid.nc'
 Error: Problems opening input file grid.nc
        This could result from an input file with no unlimited dimension.
STOP 6
```
In order to better handle the behavior across different netCDF library
versions, we now check whether the unlimited dimension exists (based on
its ID), and if not, as long as the number of variables in the files is
non-zero, we assume at least one record.