### PR TITLE
Generalize remapping code to work with output from CAM-MPAS or stand-alone MPAS

### DIFF
--- a/src/remapper.F
+++ b/src/remapper.F
@@ -52,6 +52,23 @@ module remapper
         integer, dimension(:,:,:,:), pointer :: array4i => null()
     end type target_field_type
 
+    ! Classes of fields that can be remapped
+    integer, parameter, private :: MPAS_CELL_FIELD   =  1, &  ! 0x01
+                                   MPAS_VTX_FIELD    =  2, &  ! 0x02
+                                   MPAS_EDGE_FIELD   =  4, &  ! 0x04
+                                   CAM_CELL_FIELD    = 16, &  ! 0x10
+                                   CAM_VTX_FIELD     = 32, &  ! 0x20
+                                   CAM_EDGE_FIELD    = 64, &  ! 0x40
+                                   UNSUPPORTED_FIELD = 0
+
+    ! Mask for field class to determine dimension ordering
+    integer, parameter, private :: MPAS_MASK   =   7, &  ! 0x07
+                                   CAM_MASK    = 112     ! 0x70
+
+    ! Mask for field class to determine mesh element type
+    integer, parameter, private :: CELL_MASK   =  17, &  ! 0x11
+                                   VTX_MASK    =  34, &  ! 0x22
+                                   EDGE_MASK   =  68     ! 0x44
 
     private :: nearest_cell, &
                nearest_vertex, &
@@ -306,11 +323,12 @@ module remapper
 
         type (input_field_type), intent(in) :: field
 
-        integer :: decompDim
+        integer :: fld_class
 
 
         can_remap_field = .true.
 
+        ! Check type of field
         if (field % xtype /= FIELD_TYPE_INTEGER .and. &
             field % xtype /= FIELD_TYPE_REAL .and. &
             field % xtype /= FIELD_TYPE_DOUBLE) then
@@ -318,21 +336,17 @@ module remapper
             return
         end if
 
+        ! Check dimensionality of field
         if (field % ndims == 0 .or. &
             (field % ndims == 1 .and. field % isTimeDependent)) then
             can_remap_field = .false.
             return
         end if
 
-        decompDim = field % ndims
-        if (field % isTimeDependent) then
-            decompDim = decompDim - 1
-        end if
+        ! Check ordering of dimensions
+        fld_class = field_class(field % dimnames)
 
-        if (trim(field % dimnames(decompDim)) /= 'nCells' .and. &
-            trim(field % dimnames(decompDim)) /= 'nVertices' .and. &
-            trim(field % dimnames(decompDim)) /= 'nEdges') then
-
+        if (iand(fld_class, MPAS_MASK) == 0 .and. iand(fld_class, CAM_MASK) == 0) then
             can_remap_field = .false.
             return
         end if
@@ -349,8 +363,11 @@ module remapper
         type (target_field_type), intent(out) :: dst_field
 
         integer :: idim
+        integer :: fld_class
 
         stat = 0
+
+        fld_class = field_class(src_field % dimnames)
 
         dst_field % name = src_field % name
         dst_field % xtype = src_field % xtype
@@ -371,10 +388,22 @@ module remapper
         dst_field % dimlens(2) = remap_info % dst_mesh % nlat
         dst_field % dimnames(2) = 'latitude'
 
-        do idim=1,dst_field % ndims-2
-            dst_field % dimlens(2+idim) = src_field % dimlens(idim)
-            dst_field % dimnames(2+idim) = src_field % dimnames(idim)
-        end do
+        ! Based on ordering of dimensions in source field, set dimension names
+        ! in the destination field
+        if (iand(fld_class, MPAS_MASK) > 0) then
+            do idim=1,dst_field % ndims-2
+                dst_field % dimlens(2+idim) = src_field % dimlens(idim)
+                dst_field % dimnames(2+idim) = src_field % dimnames(idim)
+            end do
+        else if (iand(fld_class, CAM_MASK) > 0) then
+            do idim=2,dst_field % ndims-1
+                dst_field % dimlens(idim+1) = src_field % dimlens(idim)
+                dst_field % dimnames(idim+1) = src_field % dimnames(idim)
+            end do
+        else
+            write(0,*) 'Remap dryrun exception: unhandled field class'
+            stat = 1
+        end if
 
     end function remap_field_dryrun
 
@@ -387,30 +416,28 @@ module remapper
         type (input_field_type), intent(in) :: src_field
         type (target_field_type), intent(out) :: dst_field
 
-        integer :: decompDim
         integer :: idim
         integer :: j
         integer :: iy, ix
         integer, dimension(:,:), pointer :: nearestIndex
         integer, dimension(:,:,:), pointer :: sourceNodes
         real, dimension(:,:,:), pointer :: nodeWeights
+        integer :: fld_class
 
         stat = 0
 
-        decompDim = src_field % ndims
-        if (src_field % isTimeDependent) then
-            decompDim = decompDim - 1
-        end if
+        fld_class = field_class(src_field % dimnames)
 
-        if (trim(src_field % dimnames(decompDim)) == 'nCells') then
+        ! Based on mesh element type, set remapping weight fields
+        if (iand(fld_class, CELL_MASK) > 0) then
             nearestIndex => remap_info % nearestCell
             sourceNodes => remap_info % sourceCells
             nodeWeights => remap_info % cellWeights
-        else if (trim(src_field % dimnames(decompDim)) == 'nVertices') then
+        else if (iand(fld_class, VTX_MASK) > 0) then
             nearestIndex => remap_info % nearestVertex
             sourceNodes => remap_info % sourceVertices
             nodeWeights => remap_info % vertexWeights
-        else if (trim(src_field % dimnames(decompDim)) == 'nEdges') then
+        else if (iand(fld_class, EDGE_MASK) > 0) then
             nearestIndex => remap_info % nearestEdge
             sourceNodes => remap_info % sourceEdges
             nodeWeights => remap_info % edgeWeights
@@ -433,14 +460,25 @@ module remapper
         allocate(dst_field % dimnames(dst_field % ndims))
         allocate(dst_field % dimlens(dst_field % ndims))
         dst_field % isTimeDependent = src_field % isTimeDependent
-        do idim=1,dst_field % ndims-2
-            dst_field % dimlens(2+idim) = src_field % dimlens(idim)
-            dst_field % dimnames(2+idim) = src_field % dimnames(idim)
-        end do
+
         dst_field % dimlens(1) = remap_info % dst_mesh % nlon
         dst_field % dimnames(1) = 'longitude'
         dst_field % dimlens(2) = remap_info % dst_mesh % nlat
         dst_field % dimnames(2) = 'latitude'
+
+        ! Based on ordering of dimensions in source field, set dimension names
+        ! in the destination field
+        if (iand(fld_class, MPAS_MASK) > 0) then
+            do idim=1,dst_field % ndims-2
+                dst_field % dimlens(2+idim) = src_field % dimlens(idim)
+                dst_field % dimnames(2+idim) = src_field % dimnames(idim)
+            end do
+        else
+            do idim=2,dst_field % ndims-1
+                dst_field % dimlens(idim+1) = src_field % dimlens(idim)
+                dst_field % dimnames(idim+1) = src_field % dimnames(idim)
+            end do
+        end if
 
         if (src_field % xtype == FIELD_TYPE_REAL) then
             if (dst_field % ndims == 2) then
@@ -487,20 +525,37 @@ module remapper
                 end do
                 end do
 #else
-                do iy=1,size(nearestIndex, dim=2)
-                do ix=1,size(nearestIndex, dim=1)
-                    if (sum(nodeWeights(:,ix,iy)) == 0.0) then
-                        dst_field % array3r(ix,iy,:) = NF90_FILL_FLOAT
-                    else
-                        dst_field % array3r(ix,iy,:) = 0.0
-                        do j=1,size(sourceNodes, dim=1)
-                            dst_field % array3r(ix,iy,:) = dst_field % array3r(ix,iy,:) + &
-                                                            nodeWeights(j,ix,iy) &
-                                                            * src_field % array2r(:,sourceNodes(j,ix,iy))
-                        end do
-                    end if
-                end do
-                end do
+                if (iand(fld_class, MPAS_MASK) > 0) then
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (sum(nodeWeights(:,ix,iy)) == 0.0) then
+                            dst_field % array3r(ix,iy,:) = NF90_FILL_FLOAT
+                        else
+                            dst_field % array3r(ix,iy,:) = 0.0
+                            do j=1,size(sourceNodes, dim=1)
+                                dst_field % array3r(ix,iy,:) = dst_field % array3r(ix,iy,:) + &
+                                                                nodeWeights(j,ix,iy) &
+                                                                * src_field % array2r(:,sourceNodes(j,ix,iy))
+                            end do
+                        end if
+                    end do
+                    end do
+                else
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (sum(nodeWeights(:,ix,iy)) == 0.0) then
+                            dst_field % array3r(ix,iy,:) = NF90_FILL_FLOAT
+                        else
+                            dst_field % array3r(ix,iy,:) = 0.0
+                            do j=1,size(sourceNodes, dim=1)
+                                dst_field % array3r(ix,iy,:) = dst_field % array3r(ix,iy,:) + &
+                                                                nodeWeights(j,ix,iy) &
+                                                                * src_field % array2r(sourceNodes(j,ix,iy),:)
+                            end do
+                        end if
+                    end do
+                    end do
+                end if
 #endif
             else if (dst_field % ndims == 4) then
                 allocate(dst_field % array4r(dst_field % dimlens(1), &
@@ -518,20 +573,37 @@ module remapper
                 end do
                 end do
 #else
-                do iy=1,size(nearestIndex, dim=2)
-                do ix=1,size(nearestIndex, dim=1)
-                    if (sum(nodeWeights(:,ix,iy)) == 0.0) then
-                        dst_field % array4r(ix,iy,:,:) = NF90_FILL_FLOAT
-                    else
-                        dst_field % array4r(ix,iy,:,:) = 0.0
-                        do j=1,size(sourceNodes, dim=1)
-                            dst_field % array4r(ix,iy,:,:) = dst_field % array4r(ix,iy,:,:) + &
-                                                              nodeWeights(j,ix,iy) &
-                                                              * src_field % array3r(:,:,sourceNodes(j,ix,iy))
-                        end do
-                    end if
-                end do
-                end do
+                if (iand(fld_class, MPAS_MASK) > 0) then
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (sum(nodeWeights(:,ix,iy)) == 0.0) then
+                            dst_field % array4r(ix,iy,:,:) = NF90_FILL_FLOAT
+                        else
+                            dst_field % array4r(ix,iy,:,:) = 0.0
+                            do j=1,size(sourceNodes, dim=1)
+                                dst_field % array4r(ix,iy,:,:) = dst_field % array4r(ix,iy,:,:) + &
+                                                                  nodeWeights(j,ix,iy) &
+                                                                  * src_field % array3r(:,:,sourceNodes(j,ix,iy))
+                            end do
+                        end if
+                    end do
+                    end do
+                else
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (sum(nodeWeights(:,ix,iy)) == 0.0) then
+                            dst_field % array4r(ix,iy,:,:) = NF90_FILL_FLOAT
+                        else
+                            dst_field % array4r(ix,iy,:,:) = 0.0
+                            do j=1,size(sourceNodes, dim=1)
+                                dst_field % array4r(ix,iy,:,:) = dst_field % array4r(ix,iy,:,:) + &
+                                                                  nodeWeights(j,ix,iy) &
+                                                                  * src_field % array3r(sourceNodes(j,ix,iy),:,:)
+                            end do
+                        end if
+                    end do
+                    end do
+                end if
 #endif
             else
                 write(0,*) 'Remap exception: unhandled dimension for real ', dst_field % ndims
@@ -581,20 +653,37 @@ module remapper
                 end do
                 end do
 #else
-                do iy=1,size(nearestIndex, dim=2)
-                do ix=1,size(nearestIndex, dim=1)
-                    if (sum(nodeWeights(:,ix,iy)) == 0.0) then
-                        dst_field % array3d(ix,iy,:) = NF90_FILL_DOUBLE
-                    else
-                        dst_field % array3d(ix,iy,:) = 0.0
-                        do j=1,size(sourceNodes, dim=1)
-                            dst_field % array3d(ix,iy,:) = dst_field % array3d(ix,iy,:) + &
-                                                            nodeWeights(j,ix,iy) &
-                                                            * src_field % array2d(:,sourceNodes(j,ix,iy))
-                        end do
-                    end if
-                end do
-                end do
+                if (iand(fld_class, MPAS_MASK) > 0) then
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (sum(nodeWeights(:,ix,iy)) == 0.0) then
+                            dst_field % array3d(ix,iy,:) = NF90_FILL_DOUBLE
+                        else
+                            dst_field % array3d(ix,iy,:) = 0.0
+                            do j=1,size(sourceNodes, dim=1)
+                                dst_field % array3d(ix,iy,:) = dst_field % array3d(ix,iy,:) + &
+                                                                nodeWeights(j,ix,iy) &
+                                                                * src_field % array2d(:,sourceNodes(j,ix,iy))
+                            end do
+                        end if
+                    end do
+                    end do
+                else
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (sum(nodeWeights(:,ix,iy)) == 0.0) then
+                            dst_field % array3d(ix,iy,:) = NF90_FILL_DOUBLE
+                        else
+                            dst_field % array3d(ix,iy,:) = 0.0
+                            do j=1,size(sourceNodes, dim=1)
+                                dst_field % array3d(ix,iy,:) = dst_field % array3d(ix,iy,:) + &
+                                                                nodeWeights(j,ix,iy) &
+                                                                * src_field % array2d(sourceNodes(j,ix,iy),:)
+                            end do
+                        end if
+                    end do
+                    end do
+                end if
 #endif
             else if (dst_field % ndims == 4) then
                 allocate(dst_field % array4d(dst_field % dimlens(1), &
@@ -612,20 +701,37 @@ module remapper
                 end do
                 end do
 #else
-                do iy=1,size(nearestIndex, dim=2)
-                do ix=1,size(nearestIndex, dim=1)
-                    if (sum(nodeWeights(:,ix,iy)) == 0.0) then
-                        dst_field % array4d(ix,iy,:,:) = NF90_FILL_DOUBLE
-                    else
-                        dst_field % array4d(ix,iy,:,:) = 0.0
-                        do j=1,size(sourceNodes, dim=1)
-                            dst_field % array4d(ix,iy,:,:) = dst_field % array4d(ix,iy,:,:) + &
-                                                              nodeWeights(j,ix,iy) &
-                                                              * src_field % array3d(:,:,sourceNodes(j,ix,iy))
-                        end do
-                    end if
-                end do
-                end do
+                if (iand(fld_class, MPAS_MASK) > 0) then
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (sum(nodeWeights(:,ix,iy)) == 0.0) then
+                            dst_field % array4d(ix,iy,:,:) = NF90_FILL_DOUBLE
+                        else
+                            dst_field % array4d(ix,iy,:,:) = 0.0
+                            do j=1,size(sourceNodes, dim=1)
+                                dst_field % array4d(ix,iy,:,:) = dst_field % array4d(ix,iy,:,:) + &
+                                                                  nodeWeights(j,ix,iy) &
+                                                                  * src_field % array3d(:,:,sourceNodes(j,ix,iy))
+                            end do
+                        end if
+                    end do
+                    end do
+                else
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (sum(nodeWeights(:,ix,iy)) == 0.0) then
+                            dst_field % array4d(ix,iy,:,:) = NF90_FILL_DOUBLE
+                        else
+                            dst_field % array4d(ix,iy,:,:) = 0.0
+                            do j=1,size(sourceNodes, dim=1)
+                                dst_field % array4d(ix,iy,:,:) = dst_field % array4d(ix,iy,:,:) + &
+                                                                  nodeWeights(j,ix,iy) &
+                                                                  * src_field % array3d(sourceNodes(j,ix,iy),:,:)
+                            end do
+                        end if
+                    end do
+                    end do
+                end if
 #endif
             else
                 write(0,*) 'Remap exception: unhandled dimension for dbl ', dst_field % ndims
@@ -647,29 +753,53 @@ module remapper
                 allocate(dst_field % array3i(dst_field % dimlens(1), &
                                              dst_field % dimlens(2), &
                                              dst_field % dimlens(3)))
-                do iy=1,size(nearestIndex, dim=2)
-                do ix=1,size(nearestIndex, dim=1)
-                    if (nearestIndex(ix,iy) == 0) then
-                        dst_field % array3i(ix,iy,:) = NF90_FILL_INT
-                    else
-                        dst_field % array3i(ix,iy,:) = src_field % array2i(:,nearestIndex(ix,iy))
-                    end if
-                end do
-                end do
+                if (iand(fld_class, MPAS_MASK) > 0) then
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (nearestIndex(ix,iy) == 0) then
+                            dst_field % array3i(ix,iy,:) = NF90_FILL_INT
+                        else
+                            dst_field % array3i(ix,iy,:) = src_field % array2i(:,nearestIndex(ix,iy))
+                        end if
+                    end do
+                    end do
+                else
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (nearestIndex(ix,iy) == 0) then
+                            dst_field % array3i(ix,iy,:) = NF90_FILL_INT
+                        else
+                            dst_field % array3i(ix,iy,:) = src_field % array2i(nearestIndex(ix,iy),:)
+                        end if
+                    end do
+                    end do
+                end if
             else if (dst_field % ndims == 4) then
                 allocate(dst_field % array4i(dst_field % dimlens(1), &
                                              dst_field % dimlens(2), &
                                              dst_field % dimlens(3), &
                                              dst_field % dimlens(4)))
-                do iy=1,size(nearestIndex, dim=2)
-                do ix=1,size(nearestIndex, dim=1)
-                    if (nearestIndex(ix,iy) == 0) then
-                        dst_field % array4i(ix,iy,:,:) = NF90_FILL_INT
-                    else
-                        dst_field % array4i(ix,iy,:,:) = src_field % array3i(:,:,nearestIndex(ix,iy))
-                    end if
-                end do
-                end do
+                if (iand(fld_class, MPAS_MASK) > 0) then
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (nearestIndex(ix,iy) == 0) then
+                            dst_field % array4i(ix,iy,:,:) = NF90_FILL_INT
+                        else
+                            dst_field % array4i(ix,iy,:,:) = src_field % array3i(:,:,nearestIndex(ix,iy))
+                        end if
+                    end do
+                    end do
+                else
+                    do iy=1,size(nearestIndex, dim=2)
+                    do ix=1,size(nearestIndex, dim=1)
+                        if (nearestIndex(ix,iy) == 0) then
+                            dst_field % array4i(ix,iy,:,:) = NF90_FILL_INT
+                        else
+                            dst_field % array4i(ix,iy,:,:) = src_field % array3i(nearestIndex(ix,iy),:,:)
+                        end if
+                    end do
+                    end do
+                end if
             else
                 write(0,*) 'Remap exception: unhandled dimension for int ', dst_field % ndims
             end if
@@ -984,7 +1114,7 @@ module remapper
         real(kind=RHI) :: wach_total                       ! The wachpress total weight
         integer :: i, j                                       ! Loop indices
         integer :: im1, i0, ip1                               ! im1 = (i-1), i0 = i, ip1 = (i+1)
-  
+
         ! triangle areas to compute wachspress coordinate
         real, dimension(nVertices) :: areaA
         real, dimension(nVertices) :: areaB
@@ -1001,7 +1131,7 @@ module remapper
                 im1 = mod(nVertices + i - 2, nVertices) + 1
                 i0  = mod(nVertices + i - 1, nVertices) + 1
                 ip1 = mod(nVertices + i    , nVertices) + 1
-   
+
                 ! precompute B_i areas
                 ! always the same because B_i independent of xp,yp,zp
                 ! (COULD CACHE AND USE RESULT FROM ARRAY FOR FURTHER OPTIMIZATION)
@@ -1021,11 +1151,11 @@ module remapper
             im1 = mod(nVertices + i - 2, nVertices) + 1
             i0  = mod(nVertices + i - 1, nVertices) + 1
             ip1 = mod(nVertices + i    , nVertices) + 1
-   
+
             ! compute A_ij areas
             ! must be computed each time
             areaA(i0) = mpas_triangle_signed_area_sphere(pointInterp, vertCoords(:, i0), vertCoords(:, ip1), radiusLocal)
-   
+
             ! precomputed B_i areas, cached
         end do
 
@@ -1076,40 +1206,40 @@ module remapper
         !-----------------------------------------------------------------
         real, dimension(3), intent(in) :: a, b, c  !< Input: 3d (x,y,z) points forming the triangle in which to calculate the bary weights
         real, intent(in) :: radius  !< sphere radius
- 
+
         !-----------------------------------------------------------------
         ! local variables
         !-----------------------------------------------------------------
         real :: ab, bc, ca, semiperim, tanqe
         real, dimension(3) :: ablen, aclen, Dlen
- 
+
         ab = mpas_arc_length(a(1), a(2), a(3), b(1), b(2), b(3))/radius
         bc = mpas_arc_length(b(1), b(2), b(3), c(1), c(2), c(3))/radius
         ca = mpas_arc_length(c(1), c(2), c(3), a(1), a(2), a(3))/radius
         semiperim = 0.5 * (ab + bc + ca)
- 
+
         tanqe = sqrt(max(0.0,tan(0.5 * semiperim) * tan(0.5 * (semiperim - ab)) &
                      * tan(0.5 * (semiperim - bc)) * tan(0.5 * (semiperim - ca))))
- 
+
         mpas_triangle_signed_area_sphere = 4.0 * radius * radius * atan(tanqe)
- 
+
         ! computing correct signs (in similar fashion to mpas_sphere_angle)
         ablen(1) = b(1) - a(1)
         ablen(2) = b(2) - a(2)
         ablen(3) = b(3) - a(3)
- 
+
         aclen(1) = c(1) - a(1)
         aclen(2) = c(2) - a(2)
         aclen(3) = c(3) - a(3)
- 
+
         dlen(1) =   (ablen(2) * aclen(3)) - (ablen(3) * aclen(2))
         dlen(2) = -((ablen(1) * aclen(3)) - (ablen(3) * aclen(1)))
         dlen(3) =   (ablen(1) * aclen(2)) - (ablen(2) * aclen(1))
- 
+
         if ((Dlen(1)*a(1) + Dlen(2)*a(2) + Dlen(3)*a(3)) < 0.0) then
             mpas_triangle_signed_area_sphere = -mpas_triangle_signed_area_sphere
         end if
- 
+
     end function mpas_triangle_signed_area_sphere
 
 
@@ -1121,23 +1251,23 @@ module remapper
     !    same sphere centered at the origin.
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     real function mpas_arc_length(ax, ay, az, bx, by, bz)
- 
+
         implicit none
- 
+
         real, intent(in) :: ax, ay, az, bx, by, bz
- 
+
         real :: r, c
         real :: cx, cy, cz
- 
+
         cx = bx - ax
         cy = by - ay
         cz = bz - az
-  
+
         r = sqrt(ax*ax + ay*ay + az*az)
         c = sqrt(cx*cx + cy*cy + cz*cz)
 
         mpas_arc_length = r * 2.0 * asin(c/(2.0*r))
- 
+
     end function mpas_arc_length
 
 
@@ -1247,5 +1377,96 @@ module remapper
         end if
 
     end function interior_element
+
+
+!-----------------------------------------------------------------------
+!  routine field_class
+!
+!> \brief Classify a field based on its dimensions
+!> \details
+!>  Given an array of dimension names for a field, return a constant indicating
+!>  whether the dimensions are for a cell-, vertex-,or edge-based field, and
+!>  whether the order of dimensions is consistent with stand-alone MPAS output
+!>  or with CAM-MPAS output.
+!
+!-----------------------------------------------------------------------
+    integer function field_class(dimnames)
+
+        implicit none
+
+        character(len=*), dimension(:), intent(in) :: dimnames
+
+        integer :: decompDim
+
+
+        field_class = UNSUPPORTED_FIELD
+
+        !
+        ! Begin by checking the names of the right-most dimension
+        !
+        decompDim = size(dimnames)
+
+        ! If this field has no dimensions, remapping is not supported
+        if (decompDim == 0) then
+            return
+        end if
+
+        !
+        ! If right-most dimension is a record dimension, move one
+        ! dimension to the left
+        !
+        if (trim(dimnames(decompDim)) == 'Time') then
+            decompDim = decompDim - 1
+        end if
+
+        ! If the record dimension was the only dimension, this field
+        ! is not supported for remapping
+        if (decompDim <= 0) then
+            return
+        end if
+
+        select case (trim(dimnames(decompDim)))
+
+            case ('nCells')
+                field_class = MPAS_CELL_FIELD
+                return
+
+            case ('nVertices')
+                field_class = MPAS_VTX_FIELD
+                return
+
+            case ('nEdges')
+                field_class = MPAS_EDGE_FIELD
+                return
+
+        end select
+
+        !
+        ! If the right-most dimension did not match any supported
+        ! dimension, try the left-most dimension
+        !
+        decompDim = 1
+
+        select case (trim(dimnames(decompDim)))
+
+            case ('nCells')
+                field_class = CAM_CELL_FIELD
+                return
+
+            case ('ncol')
+                field_class = CAM_CELL_FIELD
+                return
+
+            case ('nVertices')
+                field_class = CAM_VTX_FIELD
+                return
+
+            case ('nEdges')
+                field_class = CAM_EDGE_FIELD
+                return
+
+        end select
+
+    end function field_class
 
 end module remapper


### PR DESCRIPTION
This PR generalizes the remapping routines to work with output from both CAM-MPAS
and stand-alone MPAS-Atmosphere.

While stand-alone MPAS output always contains the mesh element dimension
(nCells, nEdges, or nVertices) as the slowest-varying dimension, CAM-MPAS
output may contain the mesh element dimension as the fastest-varying dimension.
Furthermore, CAM-MPAS may use both of the dimension names 'ncol' and 'nCells' to
refer to the cell dimension of fields.

To accommodate these different orderings and names of dimensions, this commit
introduces constants to indicate the mesh element type on which a field is
defined and the dimension ordering of that field, along with a new function to
return an appropriate constant given the list of dimension names for an input
(source) field. Masks are also provided to determine whether a field --
regardless of its dimension ordering -- is a cell-, vertex-, or edge-based
field, and whether a field uses CAM-MPAS or stand-alone MPAS dimension order.