### PR TITLE
Switch from suffix rules to pattern rules in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,3 @@
-.SUFFIXES: .F90 .o
-
 OBJS = \
 	scan_input.o \
 	mpas_mesh.o \
@@ -33,6 +31,6 @@ target_mesh.o:
 clean:
 	rm -f *.mod *.o convert_mpas
 
-.F90.o:
+%.o : %.F90
 	rm -f $@ $*.mod
-	$(FC) $(FFLAGS) -c $*.F90 $(FCINCLUDES)
+	$(FC) $(FFLAGS) -c $< $(FCINCLUDES)


### PR DESCRIPTION
This PR switches from the use of suffix rules in src/Makefile to the use of
implicit pattern rules.

Rather than using old-style suffix rules, implicit pattern rules are now used in
src/Makefile. Since the .SUFFIXES target was used to activate suffix rules, it
is no longer needed in src/Makefile.