### PR TITLE
Correct issues with netCDF library linking and loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 FC = $(shell nf-config --fc)
 FFLAGS = -O3
 FCINCLUDES = $(shell nf-config --fflags)
-FCLIBS = $(shell nf-config --flibs)
+FCLIBS = -L$(shell nc-config --libdir) $(shell nf-config --flibs)
 
 
 CHECKS = config_check netcdf_check netcdf4_check inq_varids_check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 FC = $(shell nf-config --fc)
 FFLAGS = -O3
 FCINCLUDES = $(shell nf-config --fflags)
-FCLIBS = -L$(shell nc-config --libdir) $(shell nf-config --flibs)
+RPATH_FLAGS = $(shell nf-config --flibs | grep -o -e '-L\S\+\( \|$$\)' | sed 's/^-L/-Wl,-rpath,/' | tr -d '\n')
+RPATH_FLAGS += $(shell nc-config --libs | grep -o -e '-L\S\+\( \|$$\)' | sed 's/^-L/-Wl,-rpath,/' | tr -d '\n')
+FCLIBS = -L$(shell nc-config --libdir) $(shell nf-config --flibs) $(RPATH_FLAGS)
 
 
 CHECKS = config_check netcdf_check netcdf4_check inq_varids_check


### PR DESCRIPTION
This PR makes changes to the top-level `Makefile` to address issues with netCDF library linking and loading.

Prior to this PR, the top-level `Makefile` assumed that the output of `nf-config --flibs` was sufficient to provide all library linking flags related to the netCDF library. In netCDF-Fortran 4.6.1, however, the `nf-config --flibs` output includes the netCDF-C library (`-lnetcdf`), but it does not include the library search path for this library, leading to compilation errors like
```
      ld: cannot find -lnetcdf
      ld: cannot find -lnetcdf
```
As a workaround, this PR adds `-L$(shell nc-config --libdir)` to the definition of `FCLIBS` in the `Makefile`.

Even after addressing linking errors, on systems that provide netCDF shared libraries, it was in some cases still necessary
to manually set the `LD_LIBRARY_PATH` environment variable to ensure that the netCDF libraries could be found by the loader. To work around this issue, the top-level `Makefile` now tries to extract linker rpath flags from the output of `nf-config --flibs` and `nc-config --libs`. These flags are stored in the `RPATH_FLAGS` make variable, which is then appended to the `FCLIBS` variable. With the search paths for the netCDF shared libraries included in the `convert_mpas` executable, it should no longer be necessary to manipulate the `LD_LIBRARY_PATH` environment variable.